### PR TITLE
Fix typo

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ InfluxDbStats.prototype.collectVirtualDevice = function (deviceObject) {
         else if (level === 'off') level = 0;
         else self.error('Cannot parse probe level');
     } else if (typeof(level) === 'string') {
-        level = paseFloat(level);
+        level = parseFloat(level);
     }
 
     if (typeof(level) === 'undefined' || isNaN(level)) {


### PR DESCRIPTION
As detected in z-way logs:
```
Callback execution error: ReferenceError: paseFloat is not defined
    at InfluxDbStats.collectVirtualDevice (automation/userModules/InfluxDbStats/index.js:134:17)
    at automation/userModules/InfluxDbStats/index.js:198:29
    at Function._.each._.forEach (automation/lib/underscore.js:153:9)
    at _.extend.each (automation/classes/DevicesCollection.js:181:12)
    at InfluxDbStats.updateAll (automation/userModules/InfluxDbStats/index.js:194:29)
```